### PR TITLE
Blog posts for SBV2 enablement in dev and prod

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,6 +57,9 @@
             <img src="img/espressif-devcon23-square.png" alt="DevCon 2023" width="30%" />
           </div>
 
+          <a href="https://thistle.tech/partnerships/espressif"
+            onclick="window.open(this.href); return false;">https://thistle.tech/partnerships/espressif</a>
+            <br />
           Ning Shang (Thistle Technologies)
         </section>
 
@@ -262,6 +265,14 @@ openssl rsa -in sbv2_private_dev.pem -pubout > sbv2_public_dev.pem
         <section>
           <h3>Demo: Development Signing <img src="img/devcon-logo.svg" alt="DevCon Logo" class="esplogo" /></h3>
           <iframe width="560" height="315" src="https://www.youtube.com/embed/GBi49dMq0kU" title="SBV2 Signing in Development" frameborder="0" allowfullscreen data-preload></iframe>
+
+          <br />
+          <div class="alignleft" style="font-size: 0.6em;">
+            Blog post:
+            <a href="https://thistle.tech/blog/esp32-secure-boot-v2-enablement-1"
+            onclick="window.open(this.href); return false;">Enabling Secure Boot
+            V2 on ESP32 Platforms in Development</a>
+          </div>
         </section>
 
         <section>
@@ -308,6 +319,13 @@ openssl rsa -in sbv2_private_dev.pem -pubout > sbv2_public_dev.pem
         <section>
           <h3>Demo: Production Signing <img src="img/devcon-logo.svg" alt="DevCon Logo" class="esplogo" /></h3>
           <iframe width="560" height="315" src="https://www.youtube.com/embed/TR_Ccrh4igo" title="SBV2 Signing in Production" frameborder="0" allowfullscreen data-preload></iframe>
+          <br />
+          <div class="alignleft" style="font-size: 0.6em;">
+            Blog post:
+            <a href="https://thistle.tech/blog/esp32-secure-boot-v2-enablement-2"
+            onclick="window.open(this.href); return false;">Enabling Secure Boot
+            V2 on ESP32 Platforms in Production</a>
+          </div>
         </section>
 
         <section>


### PR DESCRIPTION
Add links to blog posts on SBV2 enablement in development and in production.

Also add a link to the Thistle Espressif landing page.